### PR TITLE
Create migrations with model generator

### DIFF
--- a/lib/generators/sequel/model/model_generator.rb
+++ b/lib/generators/sequel/model/model_generator.rb
@@ -8,8 +8,14 @@ module Sequel
 
       check_class_collision
 
+      class_option :migration, :type => :boolean
       class_option :timestamps, :type => :boolean
       class_option :parent,     :type => :string, :desc => "The parent class for the generated model"
+
+      def create_migration_file
+        return unless options[:migration]
+        migration_template "migration.rb", "db/migrate/create_#{table_name}.rb"
+      end
 
       def create_model_file
         template 'model.rb', File.join('app/models', class_path, "#{file_name}.rb")

--- a/lib/generators/sequel/model/templates/migration.rb
+++ b/lib/generators/sequel/model/templates/migration.rb
@@ -1,0 +1,14 @@
+class <%= migration_file_name.camelize %>Migration < Sequel::Migration
+  def up
+    create_table :<%= table_name %> do
+      primary_key :id
+<% attributes.each do |attribute| -%>
+      <%= attribute.type_class %> :<%= attribute.name %>
+<% end -%>
+    end
+  end
+
+  def down
+    drop_table :<%= table_name %>
+  end
+end


### PR DESCRIPTION
Adding template and method (and option) to generate migration when generating a model. It was taken from the ActiveRecord model_generator, but i removed testing if parent class set (AR skips migrations if parent is set because it only supports single table inheritance), not sure what would be the optimal for sequel. I simply copied the template from migrations.
