### PR TITLE
Quick commit for allowing required config options for mysql and postgres

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ gem 'yard',                 '~> 0.5'
 
 git 'git://github.com/rails/rails.git' do
 
-  gem 'activesupport',      '~> 3.0.0.beta3', :require => 'active_support'
-  gem 'actionpack',         '~> 3.0.0.beta3', :require => 'action_pack'
-  gem 'railties',           '~> 3.0.0.beta3', :require => 'rails'
+  gem 'activesupport',      '~> 3.1.0.beta', :require => 'active_support'
+  gem 'actionpack',         '~> 3.1.0.beta', :require => 'action_pack'
+  gem 'railties',           '~> 3.1.0.beta', :require => 'rails'
 
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,81 @@
+GIT
+  remote: git://github.com/rails/rails.git
+  revision: 4532b39f5faa15af957e3b41b671f07ed201488d
+  specs:
+    actionpack (3.1.0.beta)
+      activemodel (= 3.1.0.beta)
+      activesupport (= 3.1.0.beta)
+      builder (~> 3.0.0)
+      erubis (~> 2.6.6)
+      i18n (~> 0.5.0)
+      rack (~> 1.2.1)
+      rack-cache (~> 1.0.0)
+      rack-mount (~> 0.6.13)
+      rack-test (~> 0.5.7)
+      tzinfo (~> 0.3.23)
+    activemodel (3.1.0.beta)
+      activesupport (= 3.1.0.beta)
+      bcrypt-ruby (~> 2.1.4)
+      builder (~> 3.0.0)
+      i18n (~> 0.5.0)
+    activesupport (3.1.0.beta)
+    railties (3.1.0.beta)
+      actionpack (= 3.1.0.beta)
+      activesupport (= 3.1.0.beta)
+      rake (>= 0.8.7)
+      thor (~> 0.14.4)
+
+GEM
+  remote: http://rubygems.org/
+  specs:
+    ZenTest (4.5.0)
+    abstract (1.0.0)
+    autotest (4.4.6)
+      ZenTest (>= 4.4.1)
+    bcrypt-ruby (2.1.4)
+    builder (3.0.0)
+    diff-lcs (1.1.2)
+    erubis (2.6.6)
+      abstract (>= 1.0.0)
+    git (1.2.5)
+    i18n (0.5.0)
+    jeweler (1.5.2)
+      bundler (~> 1.0.0)
+      git (>= 1.2.5)
+      rake
+    rack (1.2.2)
+    rack-cache (1.0)
+      rack (>= 0.4)
+    rack-mount (0.6.13)
+      rack (>= 1.0.0)
+    rack-test (0.5.7)
+      rack (>= 1.0)
+    rake (0.8.7)
+    rcov (0.9.9)
+    rspec (2.5.0)
+      rspec-core (~> 2.5.0)
+      rspec-expectations (~> 2.5.0)
+      rspec-mocks (~> 2.5.0)
+    rspec-core (2.5.1)
+    rspec-expectations (2.5.0)
+      diff-lcs (~> 1.1.2)
+    rspec-mocks (2.5.0)
+    sequel (3.11.0)
+    thor (0.14.6)
+    tzinfo (0.3.25)
+    yard (0.6.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  actionpack (~> 3.1.0.beta)!
+  activesupport (~> 3.1.0.beta)!
+  autotest
+  jeweler (~> 1.4)
+  railties (~> 3.1.0.beta)!
+  rake (~> 0.8.7)
+  rcov
+  rspec
+  sequel (~> 3.11.0)
+  yard (~> 0.5)

--- a/lib/sequel-rails/railties/database.rake
+++ b/lib/sequel-rails/railties/database.rake
@@ -10,12 +10,12 @@ namespace :db do
       end
       Rake::Task["db:schema:dump"].reenable
     end
-    
+
     desc "Load a schema.rb file into the database"
     task :load, :needs => :environment do
       require 'sequel-rails/storage'
       Rails::Sequel::Storage.new(Rails.env).create
-      
+
       file = ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb"
       if File.exists?(file)
         load(file)
@@ -36,15 +36,15 @@ namespace :db do
   desc "Create the database defined in config/database.yml for the current Rails.env - also creates the test database if Rails.env.development?"
   task :create, :env, :needs => :environment do |t, args|
     args.with_defaults(:env => Rails.env)
-    
+
     require 'sequel-rails/storage'
     Rails::Sequel::Storage.new(args.env).create
-    
+
     if Rails.env.development? && Rails.configuration.database_configuration['test']
       Rails::Sequel::Storage.new('test').create
     end
   end
-  
+
   namespace :drop do
     desc 'Drops all the local databases defined in config/database.yml'
     task :all, :needs => :environment do
@@ -52,14 +52,14 @@ namespace :db do
       Rails::Sequel::Storage.drop_all
     end
   end
-  
+
   desc "Create the database defined in config/database.yml for the current Rails.env - also creates the test database if Rails.env.development?"
   task :drop, :env, :needs => :environment do |t, args|
     args.with_defaults(:env => Rails.env)
-    
+
     require 'sequel-rails/storage'
     Rails::Sequel::Storage.new(args.env).drop
-    
+
     if Rails.env.development? && Rails.configuration.database_configuration['test']
       Rails::Sequel::Storage.new('test').drop
     end
@@ -101,7 +101,7 @@ namespace :db do
       Rake::Task["db:schema:dump"].invoke if Rails.env != 'test'
     end
   end
-  
+
   desc 'Migrate the database to the latest version'
   task :migrate => :'migrate:load' do
     Rails::Sequel::Migrations.migrate_up!(ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
@@ -121,22 +121,42 @@ namespace :db do
     Sequel::Migrator.forward('db/migrate/', step)
     Rake::Task["db:schema:dump"].invoke if Rails.env != 'test'
   end
-  
+
   desc 'Load the seed data from db/seeds.rb'
   task :seed => :environment do
     seed_file = File.join(Rails.root, 'db', 'seeds.rb')
     load(seed_file) if File.exist?(seed_file)
   end
-  
+
   desc 'Create the database, load the schema, and initialize with the seed data'
   task :setup => [ 'db:create', 'db:migrate', 'db:seed' ]
-  
+
   desc 'Drops and recreates the database from db/schema.rb for the current environment and loads the seeds.'
   task :reset => [ 'db:drop', 'db:setup' ]
-  
+
+  desc 'Forcibly close any open connections to the test database'
+  task :force_close_open_connections => :environment do
+    if Rails.env.test?
+       db_config = Rails.configuration.database_configuration[Rails.env].symbolize_keys
+
+       begin
+         #Will only work on Postgres > 8.4
+         db_adapter.execute <<-SQL.gsub(/^\s{9}/,'')
+         SELECT COUNT(pg_terminate_backend(procpid))
+         FROM  pg_stat_activity
+         WHERE datname = '#{db_config[:database]}';
+         SQL
+       rescue => e
+         #Will raise an error as it kills existing process running this command
+         #Seems to be only way to ensure *all* test connections are closed
+       end
+     end
+  end
+
   namespace :test do
     task :prepare do
       Rails.env = 'test'
+      Rake::Task['db:force_close_open_connections'].invoke()
       Rake::Task['db:reset'].invoke()
       Sequel::DATABASES.each do |db|
         db.disconnect

--- a/lib/sequel-rails/railties/database.rake
+++ b/lib/sequel-rails/railties/database.rake
@@ -138,10 +138,9 @@ namespace :db do
   task :force_close_open_connections => :environment do
     if Rails.env.test?
        db_config = Rails.configuration.database_configuration[Rails.env].symbolize_keys
-
        begin
          #Will only work on Postgres > 8.4
-         db_adapter.execute <<-SQL.gsub(/^\s{9}/,'')
+         Sequel::Model.db.execute <<-SQL.gsub(/^\s{9}/,'')
          SELECT COUNT(pg_terminate_backend(procpid))
          FROM  pg_stat_activity
          WHERE datname = '#{db_config[:database]}';

--- a/lib/sequel-rails/storage.rb
+++ b/lib/sequel-rails/storage.rb
@@ -137,14 +137,14 @@ module Rails
       private
 
         def execute(statement)
-          system(
-            'mysql',
-            (username.blank? ? '' : "--user=#{username}"),
-            (password.blank? ? '' : "--password=#{password}"),
-            (host.blank? ? '' : "--host=#{host}"),
-            '-e',
-            statement
-          )
+          commands = 'mysql '
+          commands << "--user=#{username} "     unless username.blank?
+          commands << "--password=#{password} " unless password.blank?
+          commands << "--host=#{host} "         unless host.blank?
+          commands << '-e '
+          commands << statement
+
+          system(commands)
         end
 
         def collation
@@ -156,28 +156,24 @@ module Rails
       class Postgres < Storage
 
         def _create
-          system(
-            'createdb',
-            '--encoding',
-            charset,
-            '--username',
-            username,
-            (owner.blank? ? '' : "--owner=#{owner}"),
-            (port.blank? ? '' : "--port=#{port}"),
-            (host.blank? ? '' : "--host=#{host}"),
-            database
-          )
+          commands = "createdb --encoding=#{charset} "
+          commands << "--username=#{username} " unless username.blank?
+          commands << "--owner=#{owner} "       unless owner.blank?
+          commands << "--port=#{port} "         unless port.blank?
+          commands << "--host=#{host} "         unless host.blank?
+          commands << database
+
+          system(commands)
         end
 
         def _drop
-          system(
-            'dropdb',
-            '--username',
-            username,
-            (port.blank? ? '' : "--port=#{port}"),
-            (host.blank? ? '' : "--host=#{host}"),
-            database
-          )
+          commands = "dropdb "
+          commands << "--username=#{username} " unless username.blank?
+          commands << "--port=#{port} "         unless port.blank?
+          commands << "--host=#{host} "         unless host.blank?
+          commands << database
+
+          system(commands)
         end
       end
 


### PR DESCRIPTION
In our local setup we run create/drop on dbs from a cruise server to our seperate (remote) db. So I found I couldn't connect without some key config attributes set, especially 'host' so it doesn't default to 'localhost'.

The second commit simply adds some of these key config values to the create/drop commands on mysql and postgres if they're present in the passed database.yml.

The first commit just bumps the rails beta version, as the required one no longer exists and means i couldn't build the gemset.

Thanks for a great gem!

Tom
