### PR TITLE
rake db:migrate fix

### DIFF
--- a/lib/sequel-rails/railties/database.rake
+++ b/lib/sequel-rails/railties/database.rake
@@ -4,7 +4,7 @@ namespace :db do
     desc "Create a db/schema.rb file that can be portably used against any DB supported by Sequel"
     task :dump do
       Sequel.extension :schema_dumper
-      db = Sequel.connect(Rails.configuration.database_configuration[Rails.env])
+      db = Sequel.connect(::Rails::Sequel.configuration.environment_for(Rails.env))
       File.open(ENV['SCHEMA'] || "#{Rails.root}/db/schema.rb", "w") do |file|
         file.write(db.dump_schema_migration)
       end


### PR DESCRIPTION
fixed error Sequel::AdapterNotFound: LoadError: no such file to load -- sequel/adapters/sqlite3 when running migrate task
